### PR TITLE
Rename getFormatter() -> formatter()

### DIFF
--- a/src/main/java/io/avaje/logback/encoder/JsonbEncoder.java
+++ b/src/main/java/io/avaje/logback/encoder/JsonbEncoder.java
@@ -49,7 +49,7 @@ public final class JsonbEncoder extends EncoderBase<ILoggingEvent> {
   @Override
   public void start() {
     properties = json.properties("@timestamp", "level", "logger", "message", "thread", "stack_trace");
-    formatter = TimeZoneUtils.getFormatter(timestampPattern, timeZone.toZoneId());
+    formatter = TimeZoneUtils.formatter(timestampPattern, timeZone.toZoneId());
     fieldExtra = customFieldsMap.entrySet().stream()
             .mapToInt(e -> e.getKey().length() + e.getValue().length())
             .sum();

--- a/src/main/java/io/avaje/logback/encoder/TimeZoneUtils.java
+++ b/src/main/java/io/avaje/logback/encoder/TimeZoneUtils.java
@@ -43,7 +43,7 @@ public final class TimeZoneUtils {
     return tz;
   }
 
-  public static DateTimeFormatter getFormatter(String pattern, ZoneId zoneId) {
+  public static DateTimeFormatter formatter(String pattern, ZoneId zoneId) {
     if (pattern == null) {
       return DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(zoneId);
     }


### PR DESCRIPTION
Style wise I kind-a-dont-like-getters anymore, or more specifically methods that start with `get` that are not trivial getter methods. 

What do you think?