### PR TITLE
Add component and dev fields, Align field names, default to conservative package name trimming

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,11 +11,11 @@
 
   <groupId>io.avaje</groupId>
   <artifactId>avaje-logback-encoder</artifactId>
-  <version>0.7</version>
+  <version>0.8-RC1</version>
 
   <properties>
     <surefire.useModulePath>false</surefire.useModulePath>
-    <project.build.outputTimestamp>2025-01-08T11:36:03Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2025-01-08T21:18:50Z</project.build.outputTimestamp>
   </properties>
 
   <dependencies>

--- a/src/main/java/io/avaje/logback/encoder/StackElementFilter.java
+++ b/src/main/java/io/avaje/logback/encoder/StackElementFilter.java
@@ -37,7 +37,7 @@ public abstract class StackElementFilter {
    *
    * @return the filter
    */
-  public static final StackElementFilter any() {
+  public static StackElementFilter any() {
     return new StackElementFilter() {
       @Override
       public boolean accept(StackTraceElement element) {
@@ -53,7 +53,7 @@ public abstract class StackElementFilter {
    *
    * @return the filter
    */
-  public static final StackElementFilter withSourceInfo() {
+  public static StackElementFilter withSourceInfo() {
     return new StackElementFilter() {
       @Override
       public boolean accept(StackTraceElement element) {
@@ -68,7 +68,7 @@ public abstract class StackElementFilter {
    * @param excludes regular expressions matching {@link StackTraceElement} to filter out
    * @return the filter
    */
-  public static final StackElementFilter byPattern(final List<Pattern> excludes) {
+  public static StackElementFilter byPattern(final List<Pattern> excludes) {
     return new StackElementFilter() {
       @Override
       public boolean accept(StackTraceElement element) {

--- a/src/main/java/io/avaje/logback/encoder/TimeZoneUtils.java
+++ b/src/main/java/io/avaje/logback/encoder/TimeZoneUtils.java
@@ -4,7 +4,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.TimeZone;
 
-public final class TimeZoneUtils {
+final class TimeZoneUtils {
   /** Keyword used by {@link #setTimeZone(String)} to denote the system default time zone. */
   private static final String DEFAULT_TIMEZONE_KEYWORD = "[DEFAULT]";
 
@@ -22,7 +22,7 @@ public final class TimeZoneUtils {
    * @throws IllegalArgumentException thrown when the string is not a valid TimeZone textual
    *     representation.
    */
-  public static TimeZone parseTimeZone(String str) {
+  static TimeZone parseTimeZone(String str) {
     if (str == null || str.isBlank() || DEFAULT_TIMEZONE_KEYWORD.equalsIgnoreCase(str)) {
       return TimeZone.getDefault();
     }
@@ -43,7 +43,7 @@ public final class TimeZoneUtils {
     return tz;
   }
 
-  public static DateTimeFormatter formatter(String pattern, ZoneId zoneId) {
+  static DateTimeFormatter formatter(String pattern, ZoneId zoneId) {
     if (pattern == null) {
       return DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(zoneId);
     }

--- a/src/test/java/io/avaje/logback/encoder/JsonEncoderTest.java
+++ b/src/test/java/io/avaje/logback/encoder/JsonEncoderTest.java
@@ -76,7 +76,7 @@ class JsonEncoderTest {
         SimpleMapper simpleMapper = SimpleMapper.builder().build();
         Map<String, Object> asMap = simpleMapper.map().fromJson(bytes);
 
-        assertThat((String)asMap.get("exception")).startsWith("java.lang.NullPointerException: Cannot invoke \"String.toUpperCase()\"");
+        assertThat((String)asMap.get("exception")).startsWith("java.lang.NullPointerException: ");
     }
 
     @Test
@@ -96,7 +96,7 @@ class JsonEncoderTest {
         SimpleMapper simpleMapper = SimpleMapper.builder().build();
         Map<String, Object> asMap = simpleMapper.map().fromJson(bytes);
 
-        assertThat((String)asMap.get("exception")).startsWith("j.l.NullPointerException: Cannot invoke \"String.toUpperCase()\"");
+        assertThat((String)asMap.get("exception")).startsWith("j.l.NullPointerException: ");
     }
 
     Throwable createThrowable() {

--- a/src/test/java/io/avaje/logback/encoder/JsonEncoderTest.java
+++ b/src/test/java/io/avaje/logback/encoder/JsonEncoderTest.java
@@ -3,6 +3,7 @@ package io.avaje.logback.encoder;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import io.avaje.json.simple.SimpleMapper;
+import io.avaje.logback.encoder.abbreviator.TrimPackageAbbreviator;
 import org.junit.jupiter.api.Test;
 import ch.qos.logback.classic.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,12 +15,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JsonEncoderTest {
 
+    private final String fqcn = "org.example.Foo";
+
+    private ILoggingEvent createLogEvent() {
+        return createLogEvent(null);
+    }
+
+    private ILoggingEvent createLogEvent(Throwable throwable) {
+        Logger logger = (Logger)LoggerFactory.getLogger(fqcn);
+        return new LoggingEvent(fqcn, logger, INFO, "Hi", throwable, null);
+    }
+
     @Test
     void encode() {
-        String fqcn = "org.example.Foo";
-        Logger logger = (Logger)LoggerFactory.getLogger(fqcn);
-
-        ILoggingEvent event = new LoggingEvent(fqcn, logger, INFO, "Hi", null, null);
+        ILoggingEvent event = createLogEvent();
 
         JsonEncoder encoder = new JsonEncoder();
         encoder.start();
@@ -28,10 +37,74 @@ class JsonEncoderTest {
         SimpleMapper simpleMapper = SimpleMapper.builder().build();
         Map<String, Object> asMap = simpleMapper.map().fromJson(bytes);
 
-        assertThat((String)asMap.get("@timestamp")).isNotNull();
+        assertThat((String)asMap.get("component")).isNull();
+        assertThat((String)asMap.get("env")).isNull();
+        assertThat((String)asMap.get("timestamp")).isNotNull();
         assertThat((String)asMap.get("message")).isEqualTo("Hi");
         assertThat((String)asMap.get("level")).isEqualTo("INFO");
         assertThat((String)asMap.get("thread")).isEqualTo("main");
         assertThat((String)asMap.get("logger")).isEqualTo("org.example.Foo");
+    }
+
+    @Test
+    void encode_component() {
+        JsonEncoder encoder = new JsonEncoder();
+        encoder.setComponent("my-component");
+        encoder.setEnvironment("dev");
+        encoder.start();
+
+        byte[] bytes = encoder.encode(createLogEvent());
+
+        SimpleMapper simpleMapper = SimpleMapper.builder().build();
+        Map<String, Object> asMap = simpleMapper.map().fromJson(bytes);
+
+        assertThat((String)asMap.get("component")).isEqualTo("my-component");
+        assertThat((String)asMap.get("env")).isEqualTo("dev");
+        assertThat((String)asMap.get("timestamp")).isNotNull();
+        assertThat((String)asMap.get("message")).isEqualTo("Hi");
+        assertThat((String)asMap.get("level")).isEqualTo("INFO");
+        assertThat((String)asMap.get("thread")).isEqualTo("main");
+        assertThat((String)asMap.get("logger")).isEqualTo("org.example.Foo");
+    }
+
+    @Test
+    void throwable_usingDefault() {
+        JsonEncoder encoder = new JsonEncoder();
+        encoder.start();
+
+        byte[] bytes = encoder.encode(createLogEvent(createThrowable()));
+        SimpleMapper simpleMapper = SimpleMapper.builder().build();
+        Map<String, Object> asMap = simpleMapper.map().fromJson(bytes);
+
+        assertThat((String)asMap.get("exception")).startsWith("java.lang.NullPointerException: Cannot invoke \"String.toUpperCase()\"");
+    }
+
+    @Test
+    void throwable_usingConverter() {
+        final TrimPackageAbbreviator trimPackages = new TrimPackageAbbreviator();
+        trimPackages.setTargetLength(10);
+
+        final ShortenedThrowableConverter converter = new ShortenedThrowableConverter();
+        converter.setMaxDepthPerThrowable(3);
+        converter.setClassNameAbbreviator(trimPackages);
+
+        JsonEncoder encoder = new JsonEncoder();
+        encoder.setThrowableConverter(converter);
+        encoder.start();
+
+        byte[] bytes = encoder.encode(createLogEvent(createThrowable()));
+        SimpleMapper simpleMapper = SimpleMapper.builder().build();
+        Map<String, Object> asMap = simpleMapper.map().fromJson(bytes);
+
+        assertThat((String)asMap.get("exception")).startsWith("j.l.NullPointerException: Cannot invoke \"String.toUpperCase()\"");
+    }
+
+    Throwable createThrowable() {
+        try {
+            System.getProperty("doNotExist").toUpperCase();
+            return null;
+        } catch (Throwable e) {
+            return e;
+        }
     }
 }

--- a/src/test/java/io/avaje/logback/encoder/ShortenedThrowableConverterTest.java
+++ b/src/test/java/io/avaje/logback/encoder/ShortenedThrowableConverterTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.avaje.logback;
+package io.avaje.logback.encoder;
 
 import ch.qos.logback.classic.pattern.Abbreviator;
 import ch.qos.logback.classic.spi.ClassPackagingData;
@@ -24,7 +24,6 @@ import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.boolex.EvaluationException;
 import ch.qos.logback.core.boolex.EventEvaluator;
 import ch.qos.logback.core.pattern.Converter;
-import io.avaje.logback.encoder.ShortenedThrowableConverter;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/io/avaje/logback/encoder/abbreviator/CachingAbbreviatorTest.java
+++ b/src/test/java/io/avaje/logback/encoder/abbreviator/CachingAbbreviatorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.avaje.logback.abbreviator;
+package io.avaje.logback.encoder.abbreviator;
 
 import ch.qos.logback.classic.pattern.Abbreviator;
 import io.avaje.logback.encoder.abbreviator.CachingAbbreviator;

--- a/src/test/java/io/avaje/logback/encoder/abbreviator/TrimPackageAbbreviatorTest.java
+++ b/src/test/java/io/avaje/logback/encoder/abbreviator/TrimPackageAbbreviatorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.avaje.logback.abbreviator;
+package io.avaje.logback.encoder.abbreviator;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
- Adds component and environment field options [we desire them as standard]
- Aligning field names for timestamp and exception [alternative standard names]
- Defaults TrimPackageAbbreviator to NOT abbreviate [a more conservative default]
- Add ability to set the ThrowableHandlingConverter [more customizable]