### PR TITLE
Rename stacktrace field to align with logstash

### DIFF
--- a/src/main/java/io/avaje/logback/encoder/JsonEncoder.java
+++ b/src/main/java/io/avaje/logback/encoder/JsonEncoder.java
@@ -32,7 +32,7 @@ public final class JsonEncoder extends EncoderBase<ILoggingEvent> {
 
   public JsonEncoder() {
     this.json = JsonStream.builder().build();
-    this.properties = json.properties("component", "env", "timestamp", "level", "logger", "message", "thread", "exception");
+    this.properties = json.properties("component", "env", "timestamp", "level", "logger", "message", "thread", "stacktrace");
   }
 
   @Override

--- a/src/main/java/io/avaje/logback/encoder/ShortenedThrowableConverter.java
+++ b/src/main/java/io/avaje/logback/encoder/ShortenedThrowableConverter.java
@@ -73,7 +73,7 @@ public final class ShortenedThrowableConverter extends ThrowableHandlingConverte
 
   public static final int FULL_MAX_DEPTH_PER_THROWABLE = Integer.MAX_VALUE;
   public static final int SHORT_MAX_DEPTH_PER_THROWABLE = 3;
-  public static final int DEFAULT_MAX_DEPTH_PER_THROWABLE = FULL_MAX_DEPTH_PER_THROWABLE;
+  public static final int DEFAULT_MAX_DEPTH_PER_THROWABLE = Integer.getInteger("avaje.logback.maxDepthPerThrowable", FULL_MAX_DEPTH_PER_THROWABLE);
 
   public static final int FULL_MAX_LENGTH = Integer.MAX_VALUE;
   public static final int SHORT_MAX_LENGTH = 1024;

--- a/src/test/java/io/avaje/logback/encoder/JsonEncoderTest.java
+++ b/src/test/java/io/avaje/logback/encoder/JsonEncoderTest.java
@@ -76,7 +76,7 @@ class JsonEncoderTest {
         SimpleMapper simpleMapper = SimpleMapper.builder().build();
         Map<String, Object> asMap = simpleMapper.map().fromJson(bytes);
 
-        assertThat((String)asMap.get("exception")).startsWith("java.lang.NullPointerException: ");
+        assertThat((String)asMap.get("stacktrace")).startsWith("java.lang.NullPointerException: ");
     }
 
     @Test
@@ -96,7 +96,7 @@ class JsonEncoderTest {
         SimpleMapper simpleMapper = SimpleMapper.builder().build();
         Map<String, Object> asMap = simpleMapper.map().fromJson(bytes);
 
-        assertThat((String)asMap.get("exception")).startsWith("j.l.NullPointerException: ");
+        assertThat((String)asMap.get("stacktrace")).startsWith("j.l.NullPointerException: ");
     }
 
     Throwable createThrowable() {


### PR DESCRIPTION
Tricky field naming as AWS and Logstash do not align by default. Going with stacktrace makes sense as that is not a required AWS name and better aligns with others.