### PR TITLE
Add a AwsLambdaAppender + default component and environment for ENV variables

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+spaces_around_operators = true

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To ensure `jlink` correctly determines the runtime modules required, add the fol
 
 ```java
 module my.module {
-  requires io.avaje.logback.encoder;  
+  requires io.avaje.logback.encoder;
 }
 ```
 

--- a/src/main/java/io/avaje/logback/encoder/AwsLambdaAppender.java
+++ b/src/main/java/io/avaje/logback/encoder/AwsLambdaAppender.java
@@ -1,0 +1,42 @@
+package io.avaje.logback.encoder;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import ch.qos.logback.core.encoder.Encoder;
+
+import java.io.IOException;
+
+/**
+ * Appender to be used for AWS Lambda that defaults to using JsonEncoder.
+ */
+public final class AwsLambdaAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
+
+  private Encoder<ILoggingEvent> encoder;
+
+  public AwsLambdaAppender() {
+    this.encoder = new JsonEncoder();
+  }
+
+  @Override
+  protected void append(ILoggingEvent event) {
+    try {
+      System.out.write(encoder.encode(event));
+    } catch (IOException e) {
+      // NOTE: When actually running on AWS Lambda, an IOException would never happen
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public void start() {
+    encoder.start();
+    super.start();
+  }
+
+  /**
+   * Change the encoder from the default JsonEncoder.
+   */
+  public void setEncoder(Encoder<ILoggingEvent> encoder) {
+    this.encoder = encoder;
+  }
+}

--- a/src/main/java/io/avaje/logback/encoder/JsonEncoder.java
+++ b/src/main/java/io/avaje/logback/encoder/JsonEncoder.java
@@ -33,6 +33,8 @@ public final class JsonEncoder extends EncoderBase<ILoggingEvent> {
   public JsonEncoder() {
     this.json = JsonStream.builder().build();
     this.properties = json.properties("component", "env", "timestamp", "level", "logger", "message", "thread", "stacktrace");
+    this.component = System.getenv("COMPONENT");
+    this.environment = System.getenv("ENVIRONMENT");
   }
 
   @Override

--- a/src/test/java/io/avaje/logback/encoder/JsonEncoderTest.java
+++ b/src/test/java/io/avaje/logback/encoder/JsonEncoderTest.java
@@ -99,6 +99,16 @@ class JsonEncoderTest {
         assertThat((String)asMap.get("stacktrace")).startsWith("j.l.NullPointerException: ");
     }
 
+    @Test
+    void awsAppender() {
+      AwsLambdaAppender appender = new AwsLambdaAppender();
+      appender.start();
+
+      appender.append(createLogEvent());
+      appender.append(createLogEvent(createThrowable()));
+      appender.append(createLogEvent());
+    }
+
     Throwable createThrowable() {
         try {
             System.getProperty("doNotExist").toUpperCase();


### PR DESCRIPTION
The AwsLambdaAppender can be used in place of org.jlib:jlib-awslambda-logback for the AWS Lambda case