### PR TITLE
Put back transitive org.slf4j

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -7,5 +7,6 @@ module io.avaje.logback.encoder {
   requires transitive ch.qos.logback.classic;
   requires transitive ch.qos.logback.core;
   requires transitive io.avaje.json;
+  requires transitive org.slf4j;
 
 }


### PR DESCRIPTION
Started getting `package org.slf4j is declared in module org.slf4j, but module nima.example does not read it` errors